### PR TITLE
Better UX for path management

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ If you would rather grab a pre-built extension, grab one on the [releases](https
 Once you have the extension downloaded / compiled, you can load it in WinDbg with the below:
 ```text
 kd> .load \path\to\snapshot\target\release\snapshot.dll
+
+kd> !snapshot -h
+[snapshot] Usage: snapshot [OPTIONS] [STATE_PATH]
+
+Arguments:
+  [STATE_PATH]  The path to save the snapshot to
+
+Options:
+  -k, --kind <KIND>  The kind of snapshot to take [default: full] [possible values: active-kernel, full]
+  -h, --help         Print help
 ```
 
 Generate a full-kernel snapshot in the `c:\foo` directory with the below:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,15 +332,20 @@ fn snapshot_inner(dbg: &DebugClient, args: SnapshotArgs) -> Result<()> {
     }
 
     // Build the state path.
-    let state_path = args.state_path.unwrap_or(env::temp_dir());
-    if !state_path.exists() {
-        bail!("the directory {:?} doesn't exist", state_path);
-    }
+    let state_path = {
+        let base_path = args.state_path.unwrap_or(env::temp_dir());
+        if base_path.exists() {
+            // If the user specified a path that exists, then generate a directory name for
+            // them.
+            base_path.join(gen_state_folder_name(dbg)?)
+        } else {
+            // Otherwise, we use it as is
+            base_path
+        }
+    };
 
-    let state_path = state_path.join(gen_state_folder_name(dbg)?);
-    if !state_path.exists() {
-        fs::create_dir(&state_path)?;
-    }
+    dbg.logln(format!("Creating {}..", state_path.display()))?;
+    fs::create_dir(&state_path)?;
 
     // Build the `regs.json` / `mem.dmp` path.
     let regs_path = state_path.join("regs.json");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,6 +333,7 @@ fn snapshot_inner(dbg: &DebugClient, args: SnapshotArgs) -> Result<()> {
 
     // Build the state path.
     let state_path = {
+        // Grab the path the user gave or the temp directory.
         let base_path = args.state_path.unwrap_or(env::temp_dir());
         if base_path.exists() {
             // If the user specified a path that exists, then generate a directory name for
@@ -344,7 +345,6 @@ fn snapshot_inner(dbg: &DebugClient, args: SnapshotArgs) -> Result<()> {
         }
     };
 
-    dbg.logln(format!("Creating {}..", state_path.display()))?;
     fs::create_dir(&state_path)?;
 
     // Build the `regs.json` / `mem.dmp` path.


### PR DESCRIPTION
Those are the cases considered:
  - If a path is given and it doesn't exist. In that case, we do not generate a folder name, the user must have provided the directory where they want us to dump the files.
  - If a path is given and it does exist. In that case, we will generate a folder name for the user.
  - No path is given in which case the resulting files will be created in the temp folder, in a directory we will create.